### PR TITLE
added __future__ and past imports for Python 3 compatibility

### DIFF
--- a/web/components/html.py
+++ b/web/components/html.py
@@ -9,6 +9,8 @@ Created on Apr 2, 2017
 
 @author: jrm
 '''
+from __future__ import print_function
+from past.builtins import basestring
 from atom.api import (
     Event, Enum, ContainerList, Value, Unicode, Dict, Instance, Bool, ForwardTyped, Typed, observe
 )
@@ -118,7 +120,7 @@ class Tag(ToolkitObject):
                 #'before':self.ch #: TODO: Handle placement?
                 'value':child.render()
             }
-            print change
+            print(change)
             self._update_clients(change)
     
     def child_removed(self, child):
@@ -129,7 +131,7 @@ class Tag(ToolkitObject):
                 'name': 'children',
                 'value': u'{}'.format(id(child)),
             }
-            print change
+            print(change)
             self._update_clients(change)
                     
     def xpath(self, query, first=False): 

--- a/web/components/md.py
+++ b/web/components/md.py
@@ -9,6 +9,7 @@ Created on Aug 2, 2017
 
 @author: jrm
 '''
+from past.builtins import basestring
 from atom.api import (
     Typed, ForwardTyped, Enum, Int, Bool, List, Dict, observe
 )

--- a/web/impl/lxml_app.py
+++ b/web/impl/lxml_app.py
@@ -9,6 +9,7 @@ Created on Apr 17, 2017
 
 @author: jrm
 '''
+from past.builtins import basestring
 import sys
 import atexit
 import subprocess

--- a/web/impl/lxml_toolkit_object.py
+++ b/web/impl/lxml_toolkit_object.py
@@ -9,6 +9,7 @@ Created on Apr 12, 2017
 
 @author: jrm
 '''
+from past.builtins import basestring
 import weakref
 from atom.api import Typed,  Constant,  Event
 from web.components.html import ProxyTag


### PR DESCRIPTION
Hi I've added `from __future__ import print_function` and `from past.builtins import basestring` to resolve the compatibility issues that came up with running the hello world example in Python 3. There's another way to refactor the `basestring` thing [here](http://python-future.org/compatible_idioms.html#basestring) if you would prefer, I don't mind implementing that way instead.